### PR TITLE
Restrict tooltip injection to one web app

### DIFF
--- a/content.js
+++ b/content.js
@@ -12,11 +12,14 @@
   if (!tooltipEnabled) return;
   const tooltipData = await fetch(chrome.runtime.getURL('frontscript-tooltips.json')).then(r => r.json());
 
+  const codeMirror = document.querySelector('.CodeMirror');
+  if (!codeMirror) return;
+
   const tooltip = document.createElement('div');
   tooltip.className = "frontscript-tooltip";
   document.body.appendChild(tooltip);
 
-  document.addEventListener('mouseover', event => {
+  codeMirror.addEventListener('mouseover', event => {
     const text = event.target.textContent;
     if (!text) {
       tooltip.style.display = 'none';
@@ -42,7 +45,7 @@ ${example}`;
     tooltip.style.display = 'block';
   });
 
-  document.addEventListener('mouseout', () => {
+  codeMirror.addEventListener('mouseout', () => {
     tooltip.style.display = 'none';
   });
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "description": "Show tooltips for FrontScript keywords and functions.",
   "permissions": ["scripting", "activeTab"],
-  "host_permissions": ["<all_urls>"],
+  "host_permissions": ["https://example.com/*"],
   "action": {
     "default_popup": "popup.html",
     "default_icon": {
@@ -15,7 +15,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://*/*", "http://*/*"],
+      "matches": ["https://example.com/*"],
       "js": ["content.js"],
       "css": ["tooltip.css"],
       "run_at": "document_idle"


### PR DESCRIPTION
## Summary
- limit content script and host permissions to a single web app
- only activate tooltips inside a `CodeMirror` element

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a537f8564832daac27841fe315d10