### PR TITLE
Fix tooltip detection for macros

### DIFF
--- a/content.js
+++ b/content.js
@@ -28,28 +28,59 @@
   tooltip.className = "frontscript-tooltip";
   document.body.appendChild(tooltip);
 
-  document.addEventListener('mouseover', event => {
+  function getWordFromPoint(x, y) {
+    const range = document.caretRangeFromPoint ?
+      document.caretRangeFromPoint(x, y) :
+      (function() {
+        const pos = document.caretPositionFromPoint && document.caretPositionFromPoint(x, y);
+        if (!pos) return null;
+        const r = document.createRange();
+        r.setStart(pos.offsetNode, pos.offset);
+        r.setEnd(pos.offsetNode, pos.offset);
+        return r;
+      })();
+    if (!range || !range.startContainer) return '';
+    const node = range.startContainer;
+    const text = node.textContent || '';
+    let start = range.startOffset;
+    while (start > 0 && /[\w%]/.test(text[start - 1])) start--;
+    let end = range.startOffset;
+    while (end < text.length && /[\w%]/.test(text[end])) end++;
+
+    let word = text.slice(start, end);
+
+    if (start === 0 && node.previousSibling && node.previousSibling.nodeType === Node.TEXT_NODE) {
+      const prevText = node.previousSibling.textContent;
+      if (prevText && prevText.endsWith('%')) {
+        word = '%' + word;
+      }
+    }
+
+    if (word === '%' && node.nextSibling && node.nextSibling.nodeType === Node.TEXT_NODE) {
+      const match = /^([\w]+)/.exec(node.nextSibling.textContent || '');
+      if (match) {
+        word += match[1];
+      }
+    }
+
+    return word;
+  }
+
+  document.addEventListener('mousemove', event => {
     if (!event.target.closest('.CodeMirror')) {
       tooltip.style.display = 'none';
       return;
     }
 
-    const text = event.target.textContent;
-    if (!text) {
+    const word = getWordFromPoint(event.clientX, event.clientY);
+    const key = word.toUpperCase();
+    if (!key || !tooltipData[key]) {
       tooltip.style.display = 'none';
       return;
     }
 
-    //const words = text.trim().split(/[^\w_\.]+/);
-    const words = text.trim().match(/%?\w+/g) || [];
-    const hoveredWord = words.find(w => tooltipData[w.toUpperCase()]);
-    if (!hoveredWord) {
-      tooltip.style.display = 'none';
-      return;
-    }
-
-    const { description, example } = tooltipData[hoveredWord.toUpperCase()];
-    tooltip.innerText = `${hoveredWord.toUpperCase()}
+    const { description, example } = tooltipData[key];
+    tooltip.innerText = `${key}
 
 ${description}
 


### PR DESCRIPTION
## Summary
- improve `getWordFromPoint` to include adjacent text nodes when a keyword is split

## Testing
- `node --check content.js`


------
https://chatgpt.com/codex/tasks/task_e_6882952991d4832d97b81ad45a657d87