### PR TITLE
Improve macro detection across DOM nodes

### DIFF
--- a/content.js
+++ b/content.js
@@ -50,17 +50,35 @@
 
     let word = text.slice(start, end);
 
-    if (start === 0 && node.previousSibling) {
-      const prevText = node.previousSibling.textContent;
-      if (prevText && prevText.endsWith('%')) {
-        word = '%' + word;
+    if (start === 0) {
+      let prev = node.previousSibling;
+      while (prev && prev.textContent && /[\w%]$/.test(prev.textContent)) {
+        const prevText = prev.textContent;
+        let i = prevText.length;
+        let segment = '';
+        while (i > 0 && /[\w%]/.test(prevText[i - 1])) {
+          segment = prevText[i - 1] + segment;
+          i--;
+        }
+        word = segment + word;
+        if (i > 0) break;
+        prev = prev.previousSibling;
       }
     }
 
-    if (word === '%' && node.nextSibling) {
-      const match = /^([\w]+)/.exec(node.nextSibling.textContent || '');
-      if (match) {
-        word += match[1];
+    if (end === text.length && /[\w%]$/.test(word)) {
+      let next = node.nextSibling;
+      while (next && next.textContent && /^[\w%]/.test(next.textContent)) {
+        const nextText = next.textContent;
+        let i = 0;
+        let segment = '';
+        while (i < nextText.length && /[\w%]/.test(nextText[i])) {
+          segment += nextText[i];
+          i++;
+        }
+        word += segment;
+        if (i < nextText.length) break;
+        next = next.nextSibling;
       }
     }
 


### PR DESCRIPTION
## Summary
- extend `getWordFromPoint` so that it walks through previous and next siblings when collecting text
- this allows tooltips to resolve macros split across multiple spans

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688347159100832daf14973a30004ea3