### PR TITLE
Fix tooltip detection only on direct hover

### DIFF
--- a/content.js
+++ b/content.js
@@ -48,7 +48,10 @@
     }
     const text = node.textContent || '';
 
-    while (offset > 0 && !/[\w%]/.test(text[offset - 1])) offset--;
+    const charAtPoint = offset < text.length ? text[offset] : '';
+    if (!(/[\w%]/.test(charAtPoint))) {
+      return { word: '', prevChar: '' };
+    }
 
     let start = offset;
     while (start > 0 && /[\w%]/.test(text[start - 1])) start--;


### PR DESCRIPTION
## Summary
- update tooltip range logic to return early when hover is not over a word

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688355e489c0832da2c8d2d812a2ff35