### PR TITLE
Fix macro tooltip detection

### DIFF
--- a/content.js
+++ b/content.js
@@ -49,8 +49,13 @@
     const text = node.textContent || '';
 
     const charAtPoint = offset < text.length ? text[offset] : '';
+    const charBefore = offset > 0 ? text[offset - 1] : '';
     if (!(/[\w%]/.test(charAtPoint))) {
-      return { word: '', prevChar: '' };
+      if (/[\w%]/.test(charBefore)) {
+        offset--;
+      } else {
+        return { word: '', prevChar: '' };
+      }
     }
 
     let start = offset;


### PR DESCRIPTION
## Summary
- handle offsets that fall just after the macro symbol

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883622f4f80832d997d1cb3631360bb