### PR TITLE
Expand extension URL permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,14 @@
 {
   "manifest_version": 3,
   "name": "FrontScript Tooltip Helper",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Show tooltips for FrontScript keywords and functions.",
   "permissions": [
     "scripting",
     "activeTab"
   ],
   "host_permissions": [
-    "https://*.efrontcloud.com/*"
+    "<all_urls>"
   ],
   "action": {
     "default_popup": "popup.html",
@@ -21,7 +21,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://*.efrontcloud.com/*"
+        "<all_urls>"
       ],
       "js": [
         "content.js"
@@ -38,7 +38,7 @@
         "frontscript-tooltips.json"
       ],
       "matches": [
-        "https://*.efrontcloud.com/*"
+        "<all_urls>"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- Allow FrontScript Tooltip Helper to run on all URLs by replacing `https://*.efrontcloud.com/*` with `<all_urls>` in host permissions, content scripts, and web accessible resources
- Bump extension version to 1.3

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893cf9baa64832d8ad20720e4d9f1b7